### PR TITLE
Show all pages without requiring a wallet connected

### DIFF
--- a/src/components/UnlockWallet/UnlockWallet.tsx
+++ b/src/components/UnlockWallet/UnlockWallet.tsx
@@ -4,7 +4,7 @@ import AccountButton from '../Nav/AccountButton';
 
 const UnlockWallet = () => {
   return (
-    <Box style={{position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)'}}>
+    <Box style={{'textAlign': 'center', 'marginTop': '25px'}}>
       <AccountButton />
       {/* <Button color="primary" variant="contained" onClick={() => connect('injected')}>Unlock Wallet</Button> */}
     </Box>

--- a/src/components/WalletProviderModal/WalletProviderModal.js
+++ b/src/components/WalletProviderModal/WalletProviderModal.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
 
 const WalletProviderModal = ({ open, handleClose }) => {
   const classes = useStyles();
-  const { account, connect } = useWallet();
+  const { account, connect, error } = useWallet();
 
   useEffect(() => {
     if (account) {
@@ -39,6 +39,7 @@ const WalletProviderModal = ({ open, handleClose }) => {
     >
       <div className={classes.paper}>
         <h2>Connect Wallet</h2>
+        { error && <p style="color: red;">{ error.toString() }</p> }
         <List component="nav" aria-label="main mailbox folders">
           <WalletCard
             icon={<img src={metamaskLogo} alt="Metamask logo" style={{ height: 32 }} />}

--- a/src/components/WalletProviderModal/WalletProviderModal.js
+++ b/src/components/WalletProviderModal/WalletProviderModal.js
@@ -39,7 +39,7 @@ const WalletProviderModal = ({ open, handleClose }) => {
     >
       <div className={classes.paper}>
         <h2>Connect Wallet</h2>
-        { error && <p style="color: red;">{ error.toString() }</p> }
+        { error && <p style={{'color': 'red'}}>{ error.toString() }</p> }
         <List component="nav" aria-label="main mailbox folders">
           <WalletCard
             icon={<img src={metamaskLogo} alt="Metamask logo" style={{ height: 32 }} />}

--- a/src/hooks/useTotalStakedOnBoardroom.ts
+++ b/src/hooks/useTotalStakedOnBoardroom.ts
@@ -17,9 +17,7 @@ const useTotalStakedOnBoardroom = () => {
         console.error(err);
       }
     }
-    if (isUnlocked) {
-      fetchTotalStaked();
-    }
+    fetchTotalStaked();
   }, [isUnlocked, slowRefresh, bombFinance]);
 
   return totalStaked;

--- a/src/views/Boardroom/Boardroom.js
+++ b/src/views/Boardroom/Boardroom.js
@@ -68,8 +68,6 @@ const Boardroom = () => {
       <Helmet>
         <title>{TITLE}</title>
       </Helmet>
-      {!!account ? (
-        <>
           <Typography color="textPrimary" align="center" variant="h3" gutterBottom>
             Boardroom
           </Typography>
@@ -135,6 +133,7 @@ const Boardroom = () => {
               </Box>
             </Grid>
 
+        {!!account ? (
             <Box mt={4}>
               <StyledBoardroom>
                 <StyledCardsWrapper>
@@ -148,6 +147,9 @@ const Boardroom = () => {
                 </StyledCardsWrapper>
               </StyledBoardroom>
             </Box>
+        ) : (
+            <UnlockWallet />
+        )}
 
             {/* <Grid container justify="center" spacing={3}>
             <Grid item xs={4}>
@@ -180,6 +182,7 @@ const Boardroom = () => {
           </Grid> */}
           </Box>
 
+        {!!account && (
           <Box mt={5}>
             <Grid container justify="center" spacing={3} mt={10}>
               <Button
@@ -195,10 +198,7 @@ const Boardroom = () => {
               </Button>
             </Grid>
           </Box>
-        </>
-      ) : (
-        <UnlockWallet />
-      )}
+        )}
     </Page>
   );
 };

--- a/src/views/Bond/Bond.tsx
+++ b/src/views/Bond/Bond.tsx
@@ -2,8 +2,6 @@ import React, {useCallback, useMemo} from 'react';
 import Page from '../../components/Page';
 import {createGlobalStyle} from 'styled-components';
 import {Route, Switch, useRouteMatch} from 'react-router-dom';
-import {useWallet} from 'use-wallet';
-import UnlockWallet from '../../components/UnlockWallet';
 import PageHeader from '../../components/PageHeader';
 import ExchangeCard from './components/ExchangeCard';
 import styled from 'styled-components';
@@ -36,7 +34,6 @@ const TITLE = 'bomb.money | Bonds'
 
 const Bond: React.FC = () => {
   const {path} = useRouteMatch();
-  const {account} = useWallet();
   const bombFinance = useBombFinance();
   const addTransaction = useTransactionAdder();
   const bondStat = useBondStats();
@@ -78,8 +75,6 @@ const Bond: React.FC = () => {
               <Helmet>
         <title>{TITLE}</title>
       </Helmet>
-        {!!account ? (
-          <>
             <Route exact path={path}>
               <PageHeader icon={'💣'} title="Buy &amp; Redeem Bonds" subtitle="Earn premiums upon redemption" />
             </Route>
@@ -143,10 +138,6 @@ const Bond: React.FC = () => {
                 />
               </StyledCardWrapper>
             </StyledBond>
-          </>
-        ) : (
-          <UnlockWallet />
-        )}
       </Page>
     </Switch>
   );

--- a/src/views/Bond/components/ExchangeCard.tsx
+++ b/src/views/Bond/components/ExchangeCard.tsx
@@ -17,6 +17,8 @@ import ERC20 from '../../../bomb-finance/ERC20';
 import useTokenBalance from '../../../hooks/useTokenBalance';
 import useApprove, {ApprovalState} from '../../../hooks/useApprove';
 import useCatchError from '../../../hooks/useCatchError';
+import { useWallet } from "use-wallet";
+import UnlockWallet from '../../../components/UnlockWallet';
 
 interface ExchangeCardProps {
   action: string;
@@ -47,6 +49,7 @@ const ExchangeCard: React.FC<ExchangeCardProps> = ({
   } = useBombFinance();
   const [approveStatus, approve] = useApprove(fromToken, Treasury.address);
 
+  const {account} = useWallet();
   const balance = useTokenBalance(fromToken);
   const [onPresent, onDismiss] = useModal(
     <ExchangeModal
@@ -85,22 +88,28 @@ const ExchangeCard: React.FC<ExchangeCardProps> = ({
           </StyledExchanger>
           <StyledDesc>{priceDesc}</StyledDesc>
           <StyledCardActions>
-            {approveStatus !== ApprovalState.APPROVED && !disabled ? (
-              <Button
-                className="shinyButton"
-                disabled={approveStatus === ApprovalState.PENDING || approveStatus === ApprovalState.UNKNOWN}
-                onClick={() => catchError(approve(), `Unable to approve ${fromTokenName}`)}
-              >
-                {`Approve ${fromTokenName}`}
-              </Button>
+            {!!account ? (
+              <>
+              {approveStatus !== ApprovalState.APPROVED && !disabled ? (
+                <Button
+                  className="shinyButton"
+                  disabled={approveStatus === ApprovalState.PENDING || approveStatus === ApprovalState.UNKNOWN}
+                  onClick={() => catchError(approve(), `Unable to approve ${fromTokenName}`)}
+                >
+                  {`Approve ${fromTokenName}`}
+                </Button>
+              ) : (
+                <Button
+                  className={disabled ? 'shinyButtonDisabled' : 'shinyButton'}
+                  onClick={onPresent}
+                  disabled={disabled}
+                >
+                  {disabledDescription || action}
+                </Button>
+              )}
+              </>
             ) : (
-              <Button
-                className={disabled ? 'shinyButtonDisabled' : 'shinyButton'}
-                onClick={onPresent}
-                disabled={disabled}
-              >
-                {disabledDescription || action}
-              </Button>
+              <UnlockWallet />
             )}
           </StyledCardActions>
         </StyledCardContentInner>

--- a/src/views/Farm/Farm.js
+++ b/src/views/Farm/Farm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useWallet } from 'use-wallet';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import Bank from '../Bank';
 
@@ -7,7 +6,6 @@ import { Box, Container, Typography, Grid } from '@material-ui/core';
 
 import { Alert } from '@material-ui/lab';
 
-import UnlockWallet from '../../components/UnlockWallet';
 import Page from '../../components/Page';
 import FarmCard from './FarmCard';
 //import FarmImage from '../../assets/img/farm.png';
@@ -30,7 +28,6 @@ const TITLE = 'bomb.money | Farms';
 const Farm = () => {
   const [banks] = useBanks();
   const { path } = useRouteMatch();
-  const { account } = useWallet();
   const activeBanks = banks.filter((bank) => !bank.finished);
   return (
     <Switch>
@@ -40,7 +37,6 @@ const Farm = () => {
           <Helmet>
             <title>{TITLE}</title>
           </Helmet>
-          {!!account ? (
             <Container maxWidth="lg">
               <Typography color="textPrimary" align="center" variant="h3" gutterBottom>
                 Reward Farms
@@ -127,9 +123,6 @@ const Farm = () => {
                 </div>
               </Box>
             </Container>
-          ) : (
-            <UnlockWallet />
-          )}
         </Route>
         <Route path={`${path}/:bankId`}>
           <BackgroundImage />

--- a/src/views/Farm/FarmCard.js
+++ b/src/views/Farm/FarmCard.js
@@ -3,8 +3,12 @@ import { Link } from 'react-router-dom';
 import { Box, Button, Card, CardActions, CardContent, Typography, Grid } from '@material-ui/core';
 
 import TokenSymbol from '../../components/TokenSymbol';
+import { useWallet } from 'use-wallet';
+import UnlockWallet from '../../components/UnlockWallet';
 
 const FarmCard = ({ bank }) => {
+  const { account } = useWallet();
+
   let depositToken = bank.depositTokenName.toUpperCase();
   if (depositToken === '80BOMB-20BTCB-LP') {
     depositToken = 'BOMB-MAXI';
@@ -43,9 +47,13 @@ const FarmCard = ({ bank }) => {
           </Box>
         </CardContent>
         <CardActions style={{ justifyContent: 'flex-end' }}>
-          <Button className="shinyButtonSecondary" component={Link} to={`/farm/${bank.contract}`}>
-            View
-          </Button>
+          {!!account ? (
+              <Button className="shinyButtonSecondary" component={Link} to={`/farm/${bank.contract}`}>
+                  View
+              </Button>
+          ) : (
+              <UnlockWallet />
+          )}
         </CardActions>
       </Card>
     </Grid>

--- a/src/views/Stake/Stake.js
+++ b/src/views/Stake/Stake.js
@@ -69,8 +69,6 @@ const Staking = () => {
       <Helmet>
         <title>{TITLE}</title>
       </Helmet>
-      {!!account ? (
-        <>
           <Typography color="textPrimary" align="center" variant="h3" gutterBottom>
             BOMB Staking for xBOMB
           </Typography>
@@ -139,6 +137,7 @@ const Staking = () => {
                   </CardContent>
                 </Card>
               </Grid>
+              {!!account && (
               <Grid item xs={12} md={2} lg={2} className={classes.gridItem}>
                 <Card className={classes.gridItem}>
                   <CardContent align="center">
@@ -147,6 +146,7 @@ const Staking = () => {
                   </CardContent>
                 </Card>
               </Grid>
+              )}
             </Grid>
 
             <Box mt={4}>
@@ -158,7 +158,11 @@ const Staking = () => {
                   {/* <Spacer /> */}
 
                   <StyledCardWrapper>
-                    <Stake />
+                    {!!account ? (
+                      <Stake />
+                    ) : (
+                        <UnlockWallet />
+                    )}
                   </StyledCardWrapper>
                 </StyledCardsWrapper>
               </StyledBoardroom>
@@ -240,10 +244,6 @@ const Staking = () => {
               </Button>
             </Grid>
           </Box> */}
-        </>
-      ) : (
-        <UnlockWallet />
-      )}
     </Page>
   );
 };


### PR DESCRIPTION
This PR attempts to solve the issue where a wallet was required to view most pages like boardroom, farms, xbomb etc.

It also makes connection errors visible in the modal (the errors are not all very user-friendly, but its better than showing nothing)
![image](https://user-images.githubusercontent.com/1296821/168184724-cb5ec73b-3bb5-4aa6-9726-6283b303f04e.png)
