### PR TITLE
Fixes when user is connected to different networks than BSC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import config from './config';
 import Updaters from './state/Updaters';
 import Loader from './components/Loader';
 import Popups from './components/Popups';
+import useChainId from './hooks/useChainId';
 //import Regulations from './views/Regulations/Regulations';
 import {RefreshContextProvider} from './contexts/RefreshContext';
 
@@ -85,11 +86,17 @@ const App: React.FC = () => {
   );
 };
 
+const UseWalletProviderWrapper = (props: any) => {
+  const chainId = useChainId();
+
+  return <UseWalletProvider chainId={chainId} {...props}></UseWalletProvider>;
+}
+
 const Providers: React.FC = ({children}) => {
   return (
     <TP1 theme={theme}>
       <TP theme={newTheme}>
-        <UseWalletProvider
+        <UseWalletProviderWrapper
                     chainId={config.chainId}
 
           connectors={{
@@ -116,7 +123,7 @@ const Providers: React.FC = ({children}) => {
               </BombFinanceProvider>
             </RefreshContextProvider>
           </Provider>
-        </UseWalletProvider>
+        </UseWalletProviderWrapper>
       </TP>
     </TP1>
   );

--- a/src/components/WalletProviderModal/WalletProviderModal.js
+++ b/src/components/WalletProviderModal/WalletProviderModal.js
@@ -6,6 +6,8 @@ import metamaskLogo from '../../assets/img/metamask-fox.svg';
 import walletConnectLogo from '../../assets/img/wallet-connect.svg';
 import coingBaseLogo from '../../assets/img/coinbase_logo.jpeg';
 import { useWallet } from 'use-wallet';
+import config from '../../config';
+import { connectToNetwork } from '../../hooks/useNetworkPrompt';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -22,6 +24,7 @@ const useStyles = makeStyles((theme) => ({
 const WalletProviderModal = ({ open, handleClose }) => {
   const classes = useStyles();
   const { account, connect } = useWallet();
+  const {ethereum} = window;
 
   useEffect(() => {
     if (account) {
@@ -42,21 +45,24 @@ const WalletProviderModal = ({ open, handleClose }) => {
         <List component="nav" aria-label="main mailbox folders">
           <WalletCard
             icon={<img src={metamaskLogo} alt="Metamask logo" style={{ height: 32 }} />}
-            onConnect={() => {
+            onConnect={async () => {
+              if (ethereum && ethereum.networkVersion !== config.chainId.toString()) {
+                await connectToNetwork(ethereum);
+              }
               connect('injected');
             }}
             title="Metamask"
           />
           <WalletCard
             icon={<img src={walletConnectLogo} alt="Wallet Connect logo" style={{ height: 24, color: 'white' }} />}
-            onConnect={() => {
+            onConnect={async () => {
               connect('walletconnect');
             }}
             title="WalletConnect"
           />
           <WalletCard
             icon={<img src={coingBaseLogo} alt="Coinbase wallet logo" style={{ height: 32, color: 'white' }} />}
-            onConnect={() => {
+            onConnect={async () => {
               connect('walletlink');
             }}
             title="Coinbase Wallet"

--- a/src/hooks/useChainId.js
+++ b/src/hooks/useChainId.js
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useChainId = () => {
+    const [chainId, setChainId] = useState(97);
+
+    const fetchChainId = useCallback(async () => {
+        if (window.ethereum) {
+            const ethereum = window.ethereum;
+            let chainId = await ethereum.request({
+                method: 'eth_chainId',
+            });
+            chainId = parseInt(chainId, 16);
+            setChainId(chainId);
+
+            window.ethereum.on('networkChanged', function (chainId) {
+                chainId = parseInt(chainId, 16);
+                setChainId(chainId);
+            });
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchChainId().catch((err) => console.error(err.stack));
+
+        const refreshChainId = setInterval(fetchChainId, 1000);
+        return () => clearInterval(refreshChainId);
+    }, [fetchChainId]);
+
+    return chainId;
+};
+
+export default useChainId;

--- a/src/hooks/useNetworkPrompt.ts
+++ b/src/hooks/useNetworkPrompt.ts
@@ -1,34 +1,35 @@
 import {useEffect, useState} from 'react';
 import config from './../config';
 
+/**
+ * For more read https://github.com/NoahZinsmeister/web3-react/blob/6737868693adb7e1e28ae80499e19901e9aae45a/example/hooks.ts#L33
+ * And https://docs.metamask.io/guide/ethereum-provider.html
+ * @param provider ethereum provider in this case is the window.ethereum available due to metamask being installed
+ * @returns
+ */
+export const connectToNetwork = async (provider: any) => {
+  await provider.request({
+    method: 'wallet_addEthereumChain',
+    params: [
+      {
+        chainId: `0x${config.chainId.toString(16)}`,
+        chainName: config.networkName,
+        nativeCurrency: {
+          name: 'BNB',
+          symbol: 'BNB',
+          decimals: 18,
+        },
+        rpcUrls: [config.defaultProvider],
+        blockExplorerUrls: [config.ftmscanUrl],
+      },
+    ],
+  });
+};
+
 const usePromptNetwork = () => {
   const [networkPrompt, setNetworkPrompt] = useState(false);
   const {ethereum} = window as any;
 
-  /**
-   * For more read https://github.com/NoahZinsmeister/web3-react/blob/6737868693adb7e1e28ae80499e19901e9aae45a/example/hooks.ts#L33
-   * And https://docs.metamask.io/guide/ethereum-provider.html
-   * @param provider ethereum provider in this case is the window.ethereum available due to metamask being installed
-   * @returns
-   */
-  const connectToNetwork = async (provider: any) => {
-    await provider.request({
-      method: 'wallet_addEthereumChain',
-      params: [
-        {
-          chainId: `0x${config.chainId.toString(16)}`,
-          chainName: config.networkName,
-          nativeCurrency: {
-            name: 'BNB',
-            symbol: 'BNB',
-            decimals: 18,
-          },
-          rpcUrls: [config.defaultProvider],
-          blockExplorerUrls: [config.ftmscanUrl],
-        },
-      ],
-    });
-  };
   useEffect(() => {
     if (!networkPrompt) {
       if (ethereum && ethereum.networkVersion !== config.chainId.toString()) {


### PR DESCRIPTION
This PR fixes the issue where the page remained locked if the user came from a network other than BSC and then switched. Until now the page required a reload to connect after the switch. With this PR the new chain is selected automatically and will connect without needing a reload.

Additionally this PR adds a prompt to switch network when clicking Connect -> Metamask if the user is connected to a different network than BSC.